### PR TITLE
fix: isAfter/BeforeDayの比較対象とタイムゾーンが異なる場合に、先頭のタイムゾーンで揃えられない

### DIFF
--- a/src/_lib/normalize.ts
+++ b/src/_lib/normalize.ts
@@ -1,0 +1,7 @@
+import type { ContextFn, DateArg } from 'date-fns'
+import { constructFrom } from 'date-fns/constructFrom'
+
+export function normalizeDates(context: ContextFn<Date> | undefined, ...dates: Array<DateArg<Date> & {}>) {
+  const normalize = constructFrom.bind(null, context || dates.find((date) => typeof date === 'object'))
+  return dates.map(normalize)
+}

--- a/src/isAfterDay/index.test.ts
+++ b/src/isAfterDay/index.test.ts
@@ -1,3 +1,5 @@
+import { TZDate } from '@date-fns/tz'
+import { isSameDay } from 'date-fns'
 import { isAfterDay } from './index'
 
 describe('isAfterDay', () => {
@@ -16,5 +18,15 @@ describe('isAfterDay', () => {
     expect(isAfterDay(new Date(2024, 10, 7, 10, 0, 0), new Date(2024, 10, 7, 0, 0, 0))).toBeFalse()
     expect(isAfterDay(new Date(2024, 10, 7, 10, 0, 0), new Date(2024, 10, 7, 23, 59, 59))).toBeFalse()
     expect(isAfterDay(new Date(2024, 10, 7, 10, 0, 0), new Date(2024, 10, 8, 0, 0, 0))).toBeFalse()
+  })
+
+  it('異なるタイムゾーン', () => {
+    const dateLeft = new TZDate(2024, 5, 7, 8, 'Asia/Singapore') // 2024-06-07T08:00:00+08:00
+    const dateRight = new TZDate(2024, 5, 6, 4, 'America/New_York') // 2024-06-06T04:00:00-04:00
+
+    expect(isSameDay(dateRight, dateLeft)).toBe(true)
+
+    expect(isAfterDay(dateLeft, dateRight)).toBe(true)
+    expect(isAfterDay(dateRight, dateLeft)).toBe(false)
   })
 })

--- a/src/isAfterDay/index.ts
+++ b/src/isAfterDay/index.ts
@@ -1,5 +1,11 @@
-import type { DateArg } from 'date-fns'
+import { normalizeDates } from '@/_lib/normalize'
+import type { ContextOptions, DateArg } from 'date-fns'
 import { startOfDay } from 'date-fns/startOfDay'
+
+/**
+ * The {@link isAfterDay} function options.
+ */
+export interface IsAfterDayOptions extends ContextOptions<Date> {}
 
 /**
  * @name isAfterDay
@@ -16,8 +22,7 @@ import { startOfDay } from 'date-fns/startOfDay'
  * const result = isAfterDay(new Date(1989, 6, 10), new Date(1987, 1, 11))
  * //=> true
  */
-export function isAfterDay(date: DateArg<Date> & {}, dateToCompare: DateArg<Date> & {}): boolean {
-  const a = startOfDay(date)
-  const b = startOfDay(dateToCompare)
-  return a > b
+export function isAfterDay(date: DateArg<Date> & {}, dateToCompare: DateArg<Date> & {}, options?: IsAfterDayOptions | undefined): boolean {
+  const [dateLeft_, dateRight_] = normalizeDates(options?.in, date, dateToCompare)
+  return +startOfDay(dateLeft_) > +startOfDay(dateRight_)
 }

--- a/src/isBeforeDay/index.test.ts
+++ b/src/isBeforeDay/index.test.ts
@@ -1,3 +1,5 @@
+import { TZDate } from '@date-fns/tz'
+import { isSameDay } from 'date-fns'
 import { isBeforeDay } from './index'
 
 describe('isBeforeDay', () => {
@@ -16,5 +18,15 @@ describe('isBeforeDay', () => {
     expect(isBeforeDay(new Date(2024, 10, 7, 10, 0, 0), new Date(2024, 10, 7, 0, 0, 0))).toBeFalse()
     expect(isBeforeDay(new Date(2024, 10, 7, 10, 0, 0), new Date(2024, 10, 7, 23, 59, 59))).toBeFalse()
     expect(isBeforeDay(new Date(2024, 10, 7, 10, 0, 0), new Date(2024, 10, 8, 0, 0, 0))).toBeTrue()
+  })
+
+  it('異なるタイムゾーン', () => {
+    const dateLeft = new TZDate(2024, 5, 7, 22, 'Asia/Singapore') // 2024-06-07T22:00:00+08:00
+    const dateRight = new TZDate(2024, 5, 6, 23, 'America/New_York') // 2024-06-06T23:00:00-04:00
+
+    expect(isSameDay(dateLeft, dateRight)).toBe(true)
+
+    expect(isBeforeDay(dateLeft, dateRight)).toBe(false)
+    expect(isBeforeDay(dateRight, dateLeft)).toBe(true)
   })
 })

--- a/src/isBeforeDay/index.ts
+++ b/src/isBeforeDay/index.ts
@@ -1,5 +1,11 @@
-import type { DateArg } from 'date-fns'
+import { normalizeDates } from '@/_lib/normalize'
+import type { ContextOptions, DateArg } from 'date-fns'
 import { startOfDay } from 'date-fns/startOfDay'
+
+/**
+ * The {@link isBeforeDay} function options.
+ */
+export interface IsBeforeDayOptions extends ContextOptions<Date> {}
 
 /**
  * @name isBeforeDay
@@ -16,8 +22,7 @@ import { startOfDay } from 'date-fns/startOfDay'
  * const result = isBeforeDay(new Date(1989, 6, 10), new Date(1987, 1, 11))
  * //=> false
  */
-export function isBeforeDay(date: DateArg<Date> & {}, dateToCompare: DateArg<Date> & {}): boolean {
-  const a = startOfDay(date)
-  const b = startOfDay(dateToCompare)
-  return a < b
+export function isBeforeDay(date: DateArg<Date> & {}, dateToCompare: DateArg<Date> & {}, options?: IsBeforeDayOptions | undefined): boolean {
+  const [dateLeft_, dateRight_] = normalizeDates(options?.in, date, dateToCompare)
+  return +startOfDay(dateLeft_) < +startOfDay(dateRight_)
 }


### PR DESCRIPTION
isSameDayと同じくタイムゾーンを揃えて比較する