### PR TITLE
Potential fix for code scanning alert no. 11: Checkout of untrusted code in trusted context

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ on:
       - "bumpver.toml"
 
 permissions:
-  contents: write
+  contents: ${{ github.event_name == 'push' && 'write' || 'read' }}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -76,7 +76,7 @@ jobs:
         run: pnpm run test:unit
 
       - name: Commit changes
-        if: ${{ matrix.node-version == 24 && github.event_name == 'pull_request' }}
+        if: ${{ matrix.node-version == 24 && github.event_name == 'push' }}
         uses: stefanzweifel/git-auto-commit-action@778341af668090896ca464160c2def5d1d1a3eb0 # v6.0.1
         with:
           commit_options: "--no-verify --signoff"


### PR DESCRIPTION
Potential fix for [https://github.com/gahojin/date-fns-japan/security/code-scanning/11](https://github.com/gahojin/date-fns-japan/security/code-scanning/11)

**How to, in general terms, fix the problem:**  
The workflow must not execute untrusted PR code in a context where it has write permissions to the repository or access to secrets. The standard fix is to separate untrusted code execution and privileged operations:  
- The `pull_request` workflow should *not* have elevated permissions and should not touch protected content or secrets.  
- Privileged operations (e.g., auto-committing changes) should only be performed in workflows triggered by trusted events (e.g., push to main, or manually triggered by a maintainer via labels or workflow_run after vetting a PR).

**Detailed description:**  
1. Remove `contents: write` permission for all events.  
2. Use GitHub's `permissions` feature to set minimal permission for PR events (`contents: read` only).  
3. Ensure that any auto-commit/push steps only run on trusted events (e.g., `push` or after approval).  
4. Consider splitting the workflow:  
   - One workflow that runs for untrusted PRs (`pull_request`) with minimal permissions, and persists results via artifact.  
   - Another workflow that runs for trusted events (e.g., `push`, or after PR approval via label/workflow_run), with elevated permissions, and performs repo writes if needed.

**Changes required:**  
- Edit `permissions` to scope rights by event.
- Restrict/refactor the auto-commit step so it only occurs on trusted events.
- If needed, split the workflow into separate `.yml` files for trusted and untrusted paths.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
