### PR TITLE
build: rolldown設定修正

### DIFF
--- a/rolldown.config.ts
+++ b/rolldown.config.ts
@@ -3,32 +3,33 @@ import { defineConfig } from 'rolldown'
 import { dts } from 'rolldown-plugin-dts'
 import pkg from './package.json'
 
-const inputIndexFiles = Object.keys(pkg.exports)
-  .filter((entry) => !entry.endsWith('.json'))
-  .map((entry) => {
-    const name = path.basename(entry)
-    const chunkName = name === '.' ? 'index' : `${name}/index`
-    return [chunkName, path.resolve('src', name, 'index.ts')]
-  })
+const getInputIndexFiles = (exports: Record<string, unknown>) => {
+  const entries = Object.keys(exports)
+    .filter((entry) => !entry.endsWith('.json'))
+    .map((entry) => {
+      const name = entry.replace(/^\.\/?/, '') || '.'
+      const chunkName = name === '.' ? 'index' : `${name}/index`
+      return [chunkName, path.resolve('src', name, 'index.ts')]
+    })
+  return Object.fromEntries(entries)
+}
 
-export default defineConfig([
-  {
-    external: ['date-fns', /^date-fns\//],
-    treeshake: {
-      moduleSideEffects: false,
-    },
-    optimization: {
-      inlineConst: true,
-    },
-    experimental: {
-      nativeMagicString: true,
-    },
-    input: Object.fromEntries(inputIndexFiles),
-    output: [{ dir: 'dist', format: 'es', sourcemap: true, cleanDir: true, comments: false }],
-    plugins: [
-      dts({
-        oxc: true,
-      }),
-    ],
+export default defineConfig({
+  external: ['date-fns', /^date-fns\//],
+  treeshake: {
+    moduleSideEffects: false,
   },
-])
+  optimization: {
+    inlineConst: true,
+  },
+  experimental: {
+    nativeMagicString: true,
+  },
+  input: getInputIndexFiles(pkg.exports),
+  output: [{ dir: 'dist', format: 'es', sourcemap: true, cleanDir: true, comments: { annotation: true, jsdoc: false, legal: true } }],
+  plugins: [
+    dts({
+      oxc: true,
+    }),
+  ],
+})


### PR DESCRIPTION
コメント出力を有効にし、package.jsonからのentryのネスト対応

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * パッケージのエクスポート設定に基づくビルド入力の生成方法を改善しました。
  * 出力時のコメント保持ルールを調整し、注釈と法的コメントを保持するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->