### PR TITLE
ci: githubのリリース作成をnpmjsリリース成功後に行う

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,9 @@
 name: Release
 
 on:
-  workflow_dispatch:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*.*.*'
 
 permissions: {}
 
@@ -15,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     strategy:
@@ -51,3 +50,9 @@ jobs:
 
       - name: Publish
         run: pnpm -r stage publish --no-git-checks
+
+      - name: Create GitHub Release
+        run: gh release create "$TAG_NAME" --generate-notes --verify-tag
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
なんらかリリースに失敗した場合に、github リリースが欠番になる恐れがあるため

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * バージョンタグのプッシュをきっかけに、リリースを自動作成できるようになりました。
  * リリースノートが自動生成されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->