### PR TITLE
chore: bump version 2026.7.3 -> 2026.8.0

### DIFF
--- a/bumpver.toml
+++ b/bumpver.toml
@@ -1,5 +1,5 @@
 [bumpver]
-current_version = "v2026.7.3"
+current_version = "v2026.8.0"
 version_pattern = "vYYYY.MM.INC0"
 commit_message = "chore: bump version {old_version_pep440} -> {new_version_pep440}"
 pre_commit_hook = ""

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gahojin-inc/date-fns-japan",
-  "version": "2026.7.3",
+  "version": "2026.8.0",
   "description": "date-fns plugin for japan",
   "author": "GAHOJIN, Inc.",
   "license": "Apache-2.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **変更**
  * アプリケーションのバージョンを **2026.8.0** に更新しました。
  * 今回の更新では、利用者向けの機能変更や操作方法の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->